### PR TITLE
Added metadata for hex.pm.

### DIFF
--- a/src/color.app.src
+++ b/src/color.app.src
@@ -10,5 +10,13 @@
                   kernel,
                   stdlib
                  ]},
-  {env, []}
+  {env, []},
+  %% Package metadata:
+  {pkg_name, erlang_color},
+  {maintainers, ["Julian Duque"]},
+  {licenses, ["MIT"]},
+  {links,
+   [{"GitHub", "https://github.com/julianduque/erlang-color"},
+    {"Hex", "https://hex.pm/packages/erlang_color"}
+   ]}
  ]}.


### PR DESCRIPTION
This is now published to Hex.pm, using these changes:
- https://hex.pm/packages/erlang_color

If you ever create an account on Hex.pm, let me know and I'll transfer ownership to you :-)
